### PR TITLE
Fix error that occurs when a document contains internal links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix error that occurs when a document contains internal links.
+
 ## 0.1.1 - 2022-05-04
 
 ### Fixed

--- a/index.js
+++ b/index.js
@@ -87,9 +87,13 @@ function convertHtml(html) {
     if (!href) {
       return;
     }
-    const url = new URL(href);
-    const q = url.searchParams.get("q");
-    element.setAttribute("href", q);
+    try {
+      const url = new URL(href);
+      const q = url.searchParams.get("q");
+      element.setAttribute("href", q);
+    } catch {
+      // Ignore invalid URL in href (e.g. `"#cmnt_ref1"`).
+    }
   });
 
   const firstElement = bodyElement.querySelector("*");


### PR DESCRIPTION
Fix https://github.com/r7kamura/google-docs-to-markdown/issues/1